### PR TITLE
Simplifying Response Serializer / Endpoint

### DIFF
--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -9,15 +9,19 @@ class Response < ActiveRecord::Base
   private
 
   def self.all_responses
-    find_by_sql("select * from responses left outer join choices on responses.choice_id = choices.id inner join questions on responses.question_id = questions.id")
+    # find_by_sql("select * from responses left outer join choices on responses.choice_id = choices.id inner join questions on responses.question_id = questions.id")
+    all
   end
 
   def self.answer_query
-    find_by_sql("select * from responses inner join questions on responses.question_id = questions.id where responses.answer_type = 'text' ")
+    # find_by_sql("select * from responses inner join questions on responses.question_id = questions.id where responses.answer_type = 'text' ")
+    where(answer_type: 'text')
   end
 
   def self.choice_query
-    find_by_sql("select * from responses left outer join choices on responses.choice_id = choices.id inner join questions on responses.question_id = questions.id where responses.answer_type = 'id' ")
+    # require 'pry'; binding.pry
+    # find_by_sql("select * from responses left outer join choices on responses.choice_id = choices.id inner join questions on responses.question_id = questions.id where responses.answer_type = 'id' ")
+    where(answer_type: 'id')
   end
 
 end

--- a/app/serializers/choice_serializer.rb
+++ b/app/serializers/choice_serializer.rb
@@ -1,0 +1,10 @@
+class ChoiceSerializer
+include FastJsonapi::ObjectSerializer
+  attributes :id,
+             :choice,
+             :question_id,
+             :updated_at,
+             :created_at
+
+
+end

--- a/app/serializers/q_and_a_serializer.rb
+++ b/app/serializers/q_and_a_serializer.rb
@@ -1,10 +1,10 @@
 class QandASerializer
 include FastJsonapi::ObjectSerializer
 attributes :id,
-                :choice_id,
-                :question,
-                :choice,
-                :correct,
-                :updated_at,
-                :created_at
+            :choice_id,
+            :question,
+            :choice,
+            :correct,
+            :updated_at,
+            :created_at
 end

--- a/app/serializers/response_serializer.rb
+++ b/app/serializers/response_serializer.rb
@@ -1,15 +1,12 @@
 class ResponseSerializer
   include FastJsonapi::ObjectSerializer
   attributes :id,
-                  :question_id,
-                  :course_id,
-                  :student_id,
-                  :text_answer,
-                  :choice_id,
-                  :answer_type,
-                  :question,
-                  :choice,
-                  :correct,
-                  :updated_at,
-                  :created_at
+             :question_id,
+             :course_id,
+             :student_id,
+             :text_answer,
+             :choice_id,
+             :answer_type,
+             :updated_at,
+             :created_at
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,5 +35,3 @@ responses.each do |row|
     **hash, created_at: creation, updated_at: creation
   )
 end
-
-require 'pry'; binding.pry

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,7 +28,8 @@ responses = CSV.open('./db/data/responses.csv', options_hash)
 
 responses.each do |row|
   hash = row.to_hash
-  creation = hash.delete(:days_ago).days.ago
+
+  creation = hash.delete(:days_ago).days.ago.to_datetime
 
   Response.create(
     **hash, created_at: creation, updated_at: creation

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,3 +35,5 @@ responses.each do |row|
     **hash, created_at: creation, updated_at: creation
   )
 end
+
+require 'pry'; binding.pry


### PR DESCRIPTION
This makes the response serializers much simpler (and faster!); Questions and choices are no longer included, Thus it is no longer an n+1 query.

I figure the q_and_a endpoint is available for any who really want to see the full info about the questions and choices

Doing so correctly would probably take making them into a https://github.com/Netflix/fast_jsonapi#compound-document

However, the relationship between response and choice/question is tricky, so I just wanted to make sure it worked first